### PR TITLE
bumping to node 8.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM node:5.8.0
+FROM node:8.1.0
 
 RUN apt-get update \
-  && apt-get install -y apt-transport-https
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update \
-  && apt-get install -y yarn \
+  && apt-get install -y apt-transport-https \
   && apt-get clean
 
 ENV HOME=/home/node


### PR DESCRIPTION
This dockerfile installs yarn 0.24.6 for you already which is the reason
for removal of the apt-get command to install it.