### PR TITLE
node-v14.13.1_yarn-v1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV NPM_CONFIG_LOGLEVEL=info NODE_VERSION=14.13.1 YARN_VERSION=1.22.5
+ENV NPM_CONFIG_LOGLEVEL=info NODE_VERSION=14.15.4 YARN_VERSION=1.22.5
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Docker base for node projects


### PR DESCRIPTION
see nodejs.org/en/blog/release/v14.15.4 for details
 
I've set merge target to old branch - node-v14.13.1_yarn-v1.22.5 - as the merge target for a cleaner diff. 

Once this is merged, I will merge `node-v14.13.1_yarn-v1.22.5` into master, which is currently used by the front end stacks

I was able to build this locally in the rnext project 